### PR TITLE
Add method destroyCocosStudio() for CocoStudio

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -1282,6 +1282,8 @@
 		38B8E2E219E671D2002D7CE7 /* UILayoutComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38B8E2DF19E671D2002D7CE7 /* UILayoutComponent.cpp */; };
 		38B8E2E319E671D2002D7CE7 /* UILayoutComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 38B8E2E019E671D2002D7CE7 /* UILayoutComponent.h */; };
 		38B8E2E419E671D2002D7CE7 /* UILayoutComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 38B8E2E019E671D2002D7CE7 /* UILayoutComponent.h */; };
+		38D9629D1ACA9721007C6FAF /* CocoStudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */; };
+		38D9629E1ACA9721007C6FAF /* CocoStudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */; };
 		38F5263E1A48363B000DB7F7 /* ArmatureNodeReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F5263B1A48363B000DB7F7 /* ArmatureNodeReader.cpp */; };
 		38F5263F1A48363B000DB7F7 /* ArmatureNodeReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F5263B1A48363B000DB7F7 /* ArmatureNodeReader.cpp */; };
 		38F526401A48363B000DB7F7 /* ArmatureNodeReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F5263C1A48363B000DB7F7 /* ArmatureNodeReader.h */; };
@@ -3109,6 +3111,7 @@
 		38B8E2D419E66581002D7CE7 /* CSLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSLoader.h; sourceTree = "<group>"; };
 		38B8E2DF19E671D2002D7CE7 /* UILayoutComponent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UILayoutComponent.cpp; sourceTree = "<group>"; };
 		38B8E2E019E671D2002D7CE7 /* UILayoutComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UILayoutComponent.h; sourceTree = "<group>"; };
+		38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CocoStudio.cpp; sourceTree = "<group>"; };
 		38F5263B1A48363B000DB7F7 /* ArmatureNodeReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ArmatureNodeReader.cpp; sourceTree = "<group>"; };
 		38F5263C1A48363B000DB7F7 /* ArmatureNodeReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArmatureNodeReader.h; sourceTree = "<group>"; };
 		38F5263D1A48363B000DB7F7 /* CSArmatureNode_generated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSArmatureNode_generated.h; sourceTree = "<group>"; };
@@ -4868,6 +4871,7 @@
 				1A8C5984180E930E00EF57C3 /* CCUtilMath.cpp */,
 				1A8C5985180E930E00EF57C3 /* CCUtilMath.h */,
 				1A8C5986180E930E00EF57C3 /* CocoStudio.h */,
+				38D9629C1ACA9721007C6FAF /* CocoStudio.cpp */,
 				1A8C5989180E930E00EF57C3 /* DictionaryHelper.cpp */,
 				1A8C598A180E930E00EF57C3 /* DictionaryHelper.h */,
 			);
@@ -8602,6 +8606,7 @@
 				B665E2561AA80A6500DDB1C5 /* CCPUDoAffectorEventHandlerTranslator.cpp in Sources */,
 				15AE18A419AAD33D00C27E9E /* CCScale9SpriteLoader.cpp in Sources */,
 				182C5CD61A98F30500C30D34 /* Sprite3DReader.cpp in Sources */,
+				38D9629D1ACA9721007C6FAF /* CocoStudio.cpp in Sources */,
 				B665E3D61AA80A6600DDB1C5 /* CCPUScriptParser.cpp in Sources */,
 				15AE1B5719AADA9900C27E9E /* UISlider.cpp in Sources */,
 				B665E2F61AA80A6500DDB1C5 /* CCPUListener.cpp in Sources */,
@@ -9044,6 +9049,7 @@
 				B665E3AF1AA80A6500DDB1C5 /* CCPURender.cpp in Sources */,
 				382383FB1A258FA7002C4610 /* idl_gen_go.cpp in Sources */,
 				B665E2EF1AA80A6500DDB1C5 /* CCPULineEmitter.cpp in Sources */,
+				38D9629E1ACA9721007C6FAF /* CocoStudio.cpp in Sources */,
 				50ABBDBA1925AB4100A911A9 /* CCTextureAtlas.cpp in Sources */,
 				1A5702FB180BCE750088DEC7 /* CCTMXXMLParser.cpp in Sources */,
 				B665E40B1AA80A6600DDB1C5 /* CCPUSphereSurfaceEmitterTranslator.cpp in Sources */,

--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -514,6 +514,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClCompile Include="..\editor-support\cocostudio\CCTween.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CCUtilMath.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CocoLoader.cpp" />
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\DictionaryHelper.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\FlatBuffersSerialize.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\TriggerBase.cpp" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -1795,6 +1795,9 @@
     <ClCompile Include="..\editor-support\cocostudio\CCObjectExtensionData.cpp">
       <Filter>cocostudio\json</Filter>
     </ClCompile>
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp">
+      <Filter>cocostudio\json</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\physics\CCPhysicsBody.h">

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems
@@ -947,6 +947,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CCTween.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CCUtilMath.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CocoLoader.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CocoStudio.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\DictionaryHelper.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\FlatBuffersSerialize.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\TriggerBase.cpp" />

--- a/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
+++ b/cocos/2d/libcocos2d_8_1/libcocos2d_8_1/libcocos2d_8_1.Shared/libcocos2d_8_1.Shared.vcxitems.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)targetver.h" />
@@ -3311,6 +3311,9 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\3d\CCTextureCube.cpp">
       <Filter>3d</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\..\editor-support\cocostudio\CocoStudio.cpp">
+      <Filter>cocostudio\json</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/2d/libcocos2d_wp8.vcxproj
+++ b/cocos/2d/libcocos2d_wp8.vcxproj
@@ -538,6 +538,7 @@
     <ClInclude Include="..\editor-support\cocostudio\CCTween.h" />
     <ClInclude Include="..\editor-support\cocostudio\CCUtilMath.h" />
     <ClInclude Include="..\editor-support\cocostudio\CocoLoader.h" />
+    <ClInclude Include="..\editor-support\cocostudio\CocoStudio.h" />
     <ClInclude Include="..\editor-support\cocostudio\CSParseBinary_generated.h" />
     <ClInclude Include="..\editor-support\cocostudio\CSParse3DBinary_generated.h" />
     <ClInclude Include="..\editor-support\cocostudio\DictionaryHelper.h" />
@@ -1179,6 +1180,7 @@
     <ClCompile Include="..\editor-support\cocostudio\CCTween.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CCUtilMath.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\CocoLoader.cpp" />
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\DictionaryHelper.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\FlatBuffersSerialize.cpp" />
     <ClCompile Include="..\editor-support\cocostudio\TriggerBase.cpp" />

--- a/cocos/2d/libcocos2d_wp8.vcxproj.filters
+++ b/cocos/2d/libcocos2d_wp8.vcxproj.filters
@@ -1815,6 +1815,9 @@
     <ClCompile Include="..\3d\CCTextureCube.cpp">
       <Filter>3d</Filter>
     </ClCompile>
+    <ClCompile Include="..\editor-support\cocostudio\CocoStudio.cpp">
+      <Filter>cocostudio\json</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CCAction.h">
@@ -3527,6 +3530,9 @@
     </ClInclude>
     <ClInclude Include="..\3d\CCTextureCube.h">
       <Filter>3d</Filter>
+    </ClInclude>
+    <ClInclude Include="..\editor-support\cocostudio\CocoStudio.h">
+      <Filter>cocostudio\json</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.cpp
@@ -218,40 +218,6 @@ void CSLoader::purge()
 {
 }
 
-void CSLoader::destroyCocosStudio()
-{
-    NodeReader::destroyInstance();
-    SingleNodeReader::destroyInstance();
-    SpriteReader::destroyInstance();
-    ParticleReader::destroyInstance();
-    GameMapReader::destroyInstance();
-    ProjectNodeReader::destroyInstance();
-    ComAudioReader::destroyInstance();
-    
-    WidgetReader::destroyInstance();
-    ButtonReader::destroyInstance();
-    CheckBoxReader::destroyInstance();
-    ImageViewReader::destroyInstance();
-    TextBMFontReader::destroyInstance();
-    TextReader::destroyInstance();
-    TextFieldReader::destroyInstance();
-    TextAtlasReader::destroyInstance();
-    LoadingBarReader::destroyInstance();
-    SliderReader::destroyInstance();
-    LayoutReader::destroyInstance();
-    ScrollViewReader::destroyInstance();
-    PageViewReader::destroyInstance();
-    ListViewReader::destroyInstance();
-    
-    ArmatureNodeReader::destroyInstance();
-    Node3DReader::destroyInstance();
-    Sprite3DReader::destroyInstance();
-    UserCameraReader::destroyInstance();
-    Particle3DReader::destroyInstance();
-    
-    destroyInstance();
-}
-
 void CSLoader::init()
 {
     using namespace std::placeholders;

--- a/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
+++ b/cocos/editor-support/cocostudio/ActionTimeline/CSLoader.h
@@ -73,9 +73,7 @@ public:
     
     CSLoader();
     /** @deprecated Use method destroyInstance() instead */
-    CC_DEPRECATED_ATTRIBUTE void purge();
-    
-    static void destroyCocosStudio();
+    CC_DEPRECATED_ATTRIBUTE void purge();    
     
     void init();
     

--- a/cocos/editor-support/cocostudio/Android.mk
+++ b/cocos/editor-support/cocostudio/Android.mk
@@ -75,7 +75,8 @@ ActionTimeline/CSLoader.cpp \
 FlatBuffersSerialize.cpp \
 WidgetCallBackHandlerProtocol.cpp \
 WidgetReader/ArmatureNodeReader/ArmatureNodeReader.cpp \
-CCObjectExtensionData.cpp
+CCObjectExtensionData.cpp \
+CocoStudio.cpp
 
 
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/..

--- a/cocos/editor-support/cocostudio/CMakeLists.txt
+++ b/cocos/editor-support/cocostudio/CMakeLists.txt
@@ -44,6 +44,7 @@ set(COCOS_CS_SRC
   editor-support/cocostudio/TriggerObj.cpp
   editor-support/cocostudio/FlatBuffersSerialize.cpp
   editor-support/cocostudio/CCObjectExtensionData.cpp
+  editor-support/cocostudio/CocoStudio.cpp
   editor-support/cocostudio/WidgetReader/NodeReader/NodeReader.cpp
   editor-support/cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.cpp
   editor-support/cocostudio/WidgetReader/SpriteReader/SpriteReader.cpp 

--- a/cocos/editor-support/cocostudio/CocoStudio.cpp
+++ b/cocos/editor-support/cocostudio/CocoStudio.cpp
@@ -1,0 +1,67 @@
+
+#include "CocoStudio.h"
+
+#include "cocostudio/WidgetReader/NodeReader/NodeReader.h"
+#include "cocostudio/WidgetReader/SingleNodeReader/SingleNodeReader.h"
+#include "cocostudio/WidgetReader/SpriteReader/SpriteReader.h"
+#include "cocostudio/WidgetReader/ParticleReader/ParticleReader.h"
+#include "cocostudio/WidgetReader/GameMapReader/GameMapReader.h"
+#include "cocostudio/WidgetReader/ProjectNodeReader/ProjectNodeReader.h"
+#include "cocostudio/WidgetReader/ComAudioReader/ComAudioReader.h"
+
+#include "cocostudio/WidgetReader/ButtonReader/ButtonReader.h"
+#include "cocostudio/WidgetReader/CheckBoxReader/CheckBoxReader.h"
+#include "cocostudio/WidgetReader/ImageViewReader/ImageViewReader.h"
+#include "cocostudio/WidgetReader/TextBMFontReader/TextBMFontReader.h"
+#include "cocostudio/WidgetReader/TextReader/TextReader.h"
+#include "cocostudio/WidgetReader/TextFieldReader/TextFieldReader.h"
+#include "cocostudio/WidgetReader/TextAtlasReader/TextAtlasReader.h"
+#include "cocostudio/WidgetReader/LoadingBarReader/LoadingBarReader.h"
+#include "cocostudio/WidgetReader/SliderReader/SliderReader.h"
+#include "cocostudio/WidgetReader/LayoutReader/LayoutReader.h"
+#include "cocostudio/WidgetReader/ScrollViewReader/ScrollViewReader.h"
+#include "cocostudio/WidgetReader/PageViewReader/PageViewReader.h"
+#include "cocostudio/WidgetReader/ListViewReader/ListViewReader.h"
+#include "cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h"
+#include "cocostudio/WidgetReader/Node3DReader/Node3DReader.h"
+#include "cocostudio/WidgetReader/Sprite3DReader/Sprite3DReader.h"
+#include "cocostudio/WidgetReader/UserCameraReader/UserCameraReader.h"
+#include "cocostudio/WidgetReader/Particle3DReader/Particle3DReader.h"
+
+
+namespace cocostudio
+{
+    void destroyCocosStudio()
+    {        
+        NodeReader::destroyInstance();
+        SingleNodeReader::destroyInstance();
+        SpriteReader::destroyInstance();
+        ParticleReader::destroyInstance();
+        GameMapReader::destroyInstance();
+        ProjectNodeReader::destroyInstance();
+        ComAudioReader::destroyInstance();
+        
+        WidgetReader::destroyInstance();
+        ButtonReader::destroyInstance();
+        CheckBoxReader::destroyInstance();
+        ImageViewReader::destroyInstance();
+        TextBMFontReader::destroyInstance();
+        TextReader::destroyInstance();
+        TextFieldReader::destroyInstance();
+        TextAtlasReader::destroyInstance();
+        LoadingBarReader::destroyInstance();
+        SliderReader::destroyInstance();
+        LayoutReader::destroyInstance();
+        ScrollViewReader::destroyInstance();
+        PageViewReader::destroyInstance();
+        ListViewReader::destroyInstance();
+        
+        ArmatureNodeReader::destroyInstance();
+        Node3DReader::destroyInstance();
+        Sprite3DReader::destroyInstance();
+        UserCameraReader::destroyInstance();
+        Particle3DReader::destroyInstance();
+        
+        cocos2d::CSLoader::destroyInstance();
+    }
+}

--- a/cocos/editor-support/cocostudio/CocoStudio.h
+++ b/cocos/editor-support/cocostudio/CocoStudio.h
@@ -65,4 +65,11 @@ THE SOFTWARE.
 #include "cocostudio/CocosStudioExport.h"
 #include "cocostudio/ActionTimeline/CSLoader.h"
 
+#include "cocostudio/CocosStudioExport.h"
+
+namespace cocostudio
+{
+    void CC_STUDIO_DLL destroyCocosStudio();
+}
+
 #endif

--- a/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
+++ b/cocos/editor-support/cocostudio/WidgetReader/ArmatureNodeReader/ArmatureNodeReader.h
@@ -26,7 +26,6 @@ THE SOFTWARE.
 #define __ARMATURENODEREADER_H_
 
 #include "cocos2d.h"
-#include "cocostudio/FlatBuffersSerialize.h"
 #include "cocostudio/WidgetReader/NodeReaderProtocol.h"
 #include "cocostudio/WidgetReader/NodeReaderDefine.h"
 

--- a/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.cpp
+++ b/tests/cpp-tests/Classes/CocosStudio3DTest/CocosStudio3DTest.cpp
@@ -104,7 +104,7 @@ void CocosStudio3DTestDemo::onEnter()
 
 void CocosStudio3DTestDemo::onExit()
 {
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
     
     BaseTest::onExit();
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioActionTimelineTest/ActionTimelineTestScene.cpp
@@ -165,7 +165,7 @@ void ActionTimelineTestLayer::onExit()
 
     backItem = restartItem = nextItem = nullptr;
     
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
 
     Layer::onExit();
 }

--- a/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
+++ b/tests/cpp-tests/Classes/ExtensionsTest/CocoStudioArmatureTest/ArmatureScene.cpp
@@ -200,7 +200,7 @@ void ArmatureTestLayer::onExit()
 
     backItem = restartItem = nextItem = nullptr;
     
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
 
     Layer::onExit();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/CustomTest/CustomWidgetCallbackBindTest/CustomWidgetCallbackBindTest.cpp
@@ -4,6 +4,7 @@
 
 #include "../../CustomGUIScene.h"
 #include "cocostudio/ActionTimeline/CSLoader.h"
+#include "cocostudio/CocoStudio.h"
 
 #include "base/ObjectFactory.h"
 
@@ -33,7 +34,7 @@ void CustomWidgetCallbackBindScene::onEnter()
 
 void CustomWidgetCallbackBindScene::onExit()
 {
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
     
     Scene::onExit();
 }

--- a/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
+++ b/tests/cpp-tests/Classes/UITest/CocoStudioGUITest/UIScene_Editor.cpp
@@ -21,7 +21,7 @@ UIScene_Editor::~UIScene_Editor()
 
 void UIScene_Editor::onExit()
 {
-    CSLoader::destroyCocosStudio();
+    cocostudio::destroyCocosStudio();
     
     Layer::onExit();
 }


### PR DESCRIPTION
1.  Add method destroyCocosStudio() for CocoStudio.h, CocoStudio.cpp
2.  Delete method destroyCocosStudio() of CSLoader.
